### PR TITLE
remove indentedSyntax

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ const loaders = {
   sass: (opts: Opts = {}) =>
     getStyleLoaders(
       require.resolve('sass-loader'),
-      merge(opts, { indentedSyntax: false })
+      merge(opts, {})
     ),
 
   less: (opts: Opts = {}) =>


### PR DESCRIPTION
因为 sass-loader 8.0.0 不支持 indentedSyntax，并且会报错。而且 father 的 sass-loader 版本都是 8.0.0。所以选择 remove indentedSyntax。